### PR TITLE
slackboard-cli: allow direct message like '-c @foo'

### DIFF
--- a/slackboard/cli.go
+++ b/slackboard/cli.go
@@ -55,7 +55,8 @@ func sendNotification2Slackboard(server, api, body string) error {
 }
 
 func SendNotification2SlackboardDirectly(server string, payload *SlackboardDirectPayload) error {
-	if strings.Index(payload.Payload.Channel, "#") != 0 {
+	if strings.Index(payload.Payload.Channel, "#") != 0 &&
+		strings.Index(payload.Payload.Channel, "@") != 0 {
 		payload.Payload.Channel = "#" + payload.Payload.Channel
 	}
 


### PR DESCRIPTION
This PR allow direct message via user's `@slackbot` channel. 

> Pass a username (`@chris`) as the value of channel to post to that user's `@slackbot` channel as the bot.
https://api.slack.com/methods/chat.postMessage

To send message to `foo`, run slackboard-cli like bellow.

```
slackboard-cli -c '@foo'
```
