### PR TITLE
Implement a QPS ratelimitting function

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -15,6 +15,7 @@ A configuration for Slackboard has some sections. A example is [here](conf/slack
 |port     |string|port number or unix socket path|29800  |e.g.)29800, unix:/tmp/slackboard.sock|
 |slack_url|string|Incomming Webhook url for slack|       |                                     |
 |qps      |int   |Queries to slack Per Second    |0      |0 means unlimited. See also [slack api docs](https://api.slack.com/docs/rate-limits) |
+|max_delay_duration |int   |Allowable delay message seconds    |      |must be specified when using qps > 0 and planning to process requests with sync=false |
 
 ## Tag Section
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -14,6 +14,7 @@ A configuration for Slackboard has some sections. A example is [here](conf/slack
 |---------|------|-------------------------------|-------|-------------------------------------|
 |port     |string|port number or unix socket path|29800  |e.g.)29800, unix:/tmp/slackboard.sock|
 |slack_url|string|Incomming Webhook url for slack|       |                                     |
+|qps      |int   |Queries to slack Per Second    |0      |0 means unlimited. See also [slack api docs](https://api.slack.com/docs/rate-limits) |
 
 ## Tag Section
 

--- a/Makefile
+++ b/Makefile
@@ -21,5 +21,8 @@ bin/slackboard-log: cmd/slackboard-log/slackboard-log.go slackboard/*.go
 fmt:
 	@echo $(TARGETS_NOVENDOR) | xargs go fmt
 
+test:
+	go test $(TARGETS_NOVENDOR)
+
 clean:
 	rm -rf bin/slackboard*

--- a/cmd/slackboard/slackboard.go
+++ b/cmd/slackboard/slackboard.go
@@ -24,6 +24,9 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// make qps bucket
+	slackboard.QPSEnd = slackboard.NewQPSPerSlackEndpoint(slackboard.ConfSlackboard)
+
 	// set logger
 	err = slackboard.SetLogLevel(slackboard.LogAccess, "info")
 	if err != nil {

--- a/glide.lock
+++ b/glide.lock
@@ -1,14 +1,16 @@
-hash: 70a72c6dbf4d69d2c62c1df014b0a92fb0e0530d54856859cbcb52c63259b539
-updated: 2016-04-16T23:04:26.872771715+09:00
+hash: 18036bc620c06ac2b8b7fbfe8cd58bacc53f52fd6dea32ab3f50f095fe7b6e40
+updated: 2017-01-21T23:33:40.431032489+09:00
 imports:
 - name: github.com/BurntSushi/toml
   version: bbd5bb678321a0d6e58f1099321dfa73391c1b6f
 - name: github.com/fukata/golang-stats-api-handler
   version: ab9f90f16caab828afda479fd34bfbbbba2efcee
+- name: github.com/juju/ratelimit
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177
 - name: github.com/Sirupsen/logrus
   version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
 - name: golang.org/x/sys
   version: f64b50fbea64174967a8882830d621a18ee1548e
   subpackages:
   - unix
-devImports: []
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -6,3 +6,5 @@ import:
   version: v0.10.0
 - package: github.com/fukata/golang-stats-api-handler
   version: ab9f90f16caab828afda479fd34bfbbbba2efcee
+- package: github.com/juju/ratelimit
+  version: 77ed1c8a01217656d2080ad51981f6e99adaa177

--- a/slackboard/conf.go
+++ b/slackboard/conf.go
@@ -18,6 +18,7 @@ type ConfToml struct {
 type SectionCore struct {
 	Port     string `toml:"port"`
 	SlackURL string `toml:"slack_url"`
+	QPS      int    `toml:"qps"`
 }
 
 type SectionTag struct {
@@ -43,6 +44,7 @@ func BuildDefaultConf() ConfToml {
 	// Core
 	conf.Core.Port = "29800"
 	conf.Core.SlackURL = ""
+	conf.Core.QPS = 0
 	// Log
 	conf.Log.AccessLog = "stdout"
 	conf.Log.ErrorLog = "stderr"

--- a/slackboard/conf.go
+++ b/slackboard/conf.go
@@ -16,9 +16,10 @@ type ConfToml struct {
 }
 
 type SectionCore struct {
-	Port     string `toml:"port"`
-	SlackURL string `toml:"slack_url"`
-	QPS      int    `toml:"qps"`
+	Port             string `toml:"port"`
+	SlackURL         string `toml:"slack_url"`
+	QPS              int    `toml:"qps"`
+	MaxDelayDuration int    `toml:"max_delay_duration"`
 }
 
 type SectionTag struct {
@@ -45,6 +46,7 @@ func BuildDefaultConf() ConfToml {
 	conf.Core.Port = "29800"
 	conf.Core.SlackURL = ""
 	conf.Core.QPS = 0
+	conf.Core.MaxDelayDuration = -1 // means an empty parameter
 	// Log
 	conf.Log.AccessLog = "stdout"
 	conf.Log.ErrorLog = "stderr"

--- a/slackboard/global.go
+++ b/slackboard/global.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	ConfSlackboard ConfToml
+	QPSEnd         *QPSPerSlackEndpoint
 	Topics         []Topic
 	LogAccess      *logrus.Logger
 	LogError       *logrus.Logger

--- a/slackboard/notify.go
+++ b/slackboard/notify.go
@@ -58,6 +58,10 @@ type SlackboardDirectPayload struct {
 }
 
 func sendNotification2Slack(payload *SlackPayload) error {
+	if QPSEnd != nil && !QPSEnd.Available() {
+		return fmt.Errorf("QPS ratelimit error")
+	}
+
 	body, err := json.Marshal(payload)
 	if err != nil {
 		return err

--- a/slackboard/notify.go
+++ b/slackboard/notify.go
@@ -62,6 +62,9 @@ func sendNotification2Slack(payload *SlackPayload, sync bool) (int, error) {
 		if sync && !QPSEnd.Available() {
 			return http.StatusTooManyRequests, fmt.Errorf("QPS ratelimit error")
 		}
+		if !sync && !QPSEnd.WaitAndAvailable() {
+			return http.StatusTooManyRequests, fmt.Errorf("QPS ratelimit error")
+		}
 	}
 
 	body, err := json.Marshal(payload)

--- a/slackboard/notify_test.go
+++ b/slackboard/notify_test.go
@@ -1,0 +1,172 @@
+package slackboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestNotifyDirectlyHandler(t *testing.T) {
+	var testData = []struct {
+		in  string
+		out string
+	}{
+		{
+			`{
+                "payload": {
+                    "channel": "random",
+                    "username": "slackboard",
+                    "icon_emoji": ":clipboard:",
+                    "text": "notification text",
+                    "parse": "full"
+                },
+                "sync": true
+            }`,
+			`{
+                "channel":"random",
+                "username":"slackboard",
+                "icon_emoji":":clipboard:",
+                "text":"notification text",
+                "parse":"full",
+                "attachments":null
+            }`,
+		},
+		{
+			`{
+                "payload": {
+                    "channel": "general",
+                    "username": "bot",
+                    "icon_emoji": ":information_desk_person:",
+                    "text": "notification general text",
+                    "parse": "full"
+                },
+                "sync": true
+            }`,
+			`{
+                "channel":"general",
+                "username":"bot",
+                "icon_emoji":":information_desk_person:",
+                "text":"notification general text",
+                "parse":"full",
+                "attachments":null
+            }`,
+		},
+	}
+
+	for _, tt := range testData {
+		// setup a mock slack server
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ctype := r.Header.Get("Content-Type"); ctype != "application/json" {
+				t.Errorf("content type header: got %v want %v", ctype, "application/json")
+			}
+
+			reqBody, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			jsonIsEqual, err := jsonBytesEqual(reqBody, []byte(tt.out))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !jsonIsEqual {
+				t.Errorf("unexpected body: got %v want %v", string(reqBody), tt.out)
+			}
+
+			fmt.Fprint(w, "ok")
+		}))
+		defer ts.Close()
+		ConfSlackboard.Core.SlackURL = ts.URL
+
+		// setup a test client
+		req, err := http.NewRequest(
+			"POST",
+			"/notify-directly",
+			bytes.NewBuffer([]byte(tt.in)),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(NotifyDirectlyHandler)
+		handler.ServeHTTP(rr, req)
+
+		// check a response
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("status code: got %v want %v", status, http.StatusOK)
+		}
+
+		expected := `{"message":"ok"}`
+		jsonIsEqual, err := jsonBytesEqual(rr.Body.Bytes(), []byte(expected))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !jsonIsEqual {
+			t.Errorf("unexpected body: got %v want %v", rr.Body.String(), expected)
+		}
+	}
+}
+
+func TestNotifyDirectlyHandlerSlackServerError(t *testing.T) {
+	// setup a mock slack server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Server down", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	ConfSlackboard.Core.SlackURL = ts.URL
+
+	// setup a test client
+	inJSONStr := `{
+        "payload": {
+            "channel": "random",
+            "username": "slackboard",
+            "icon_emoji": ":clipboard:",
+            "text": "notification text",
+            "parse": "full"
+        },
+        "sync": true
+    }`
+	req, err := http.NewRequest(
+		"POST",
+		"/notify-directly",
+		bytes.NewBuffer([]byte(inJSONStr)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(NotifyDirectlyHandler)
+	handler.ServeHTTP(rr, req)
+
+	// check a response
+	if status := rr.Code; status != http.StatusBadGateway {
+		t.Errorf("status code: got %v want %v", status, http.StatusBadGateway)
+	}
+
+	expected := `{"message":"failed to post message to slack"}`
+	jsonIsEqual, err := jsonBytesEqual(rr.Body.Bytes(), []byte(expected))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !jsonIsEqual {
+		t.Errorf("unexpected body: got %v want %v", rr.Body.String(), expected)
+	}
+}
+
+func jsonBytesEqual(a, b []byte) (bool, error) {
+	var j, j2 interface{}
+	if err := json.Unmarshal(a, &j); err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(b, &j2); err != nil {
+		return false, err
+	}
+	return reflect.DeepEqual(j2, j), nil
+}

--- a/slackboard/notify_test.go
+++ b/slackboard/notify_test.go
@@ -193,7 +193,7 @@ func TestNotifyDirectlyHandlerQPS(t *testing.T) {
 		{
 			1,
 			map[string]interface{}{
-				"code": http.StatusBadGateway,
+				"code": http.StatusTooManyRequests,
 				"body": `{"message":"failed to post message to slack"}`,
 			},
 		},

--- a/slackboard/qps.go
+++ b/slackboard/qps.go
@@ -2,27 +2,51 @@ package slackboard
 
 import (
 	"github.com/juju/ratelimit"
+	"time"
 )
 
+// QPSPerSlackEndpoint controls rate limiting.
 type QPSPerSlackEndpoint struct {
-	bucket *ratelimit.Bucket
+	bucket  *ratelimit.Bucket
+	maxWait *time.Duration
 }
 
+// NewQPSPerSlackEndpoint initializes QPSPerSlackEndpoint.
 func NewQPSPerSlackEndpoint(conf ConfToml) *QPSPerSlackEndpoint {
 	qps := conf.Core.QPS
 	if qps <= 0 {
 		return nil
 	}
 
+	var maxWait *time.Duration
+	duration := conf.Core.MaxDelayDuration
+	if 0 <= duration {
+		sec := time.Duration(duration) * time.Second
+		maxWait = &sec
+	}
+
 	return &QPSPerSlackEndpoint{
 		ratelimit.NewBucketWithRate(float64(qps), int64(qps)),
+		maxWait,
 	}
 }
 
+// Available takes count from the bucket.
+// If it is not available immediately, do nothing and return false.
 func (qpsend QPSPerSlackEndpoint) Available() bool {
 	if qpsend.bucket.TakeAvailable(1) == 0 {
 		return false
 	}
 
 	return true
+}
+
+// WaitAndAvailable waits until the bucket becomes available
+func (qpsend QPSPerSlackEndpoint) WaitAndAvailable() bool {
+	maxWait := qpsend.maxWait
+	if maxWait == nil {
+		// disable rate limiting
+		return true
+	}
+	return qpsend.bucket.WaitMaxDuration(1, *maxWait)
 }

--- a/slackboard/qps.go
+++ b/slackboard/qps.go
@@ -1,0 +1,28 @@
+package slackboard
+
+import (
+	"github.com/juju/ratelimit"
+)
+
+type QPSPerSlackEndpoint struct {
+	bucket *ratelimit.Bucket
+}
+
+func NewQPSPerSlackEndpoint(conf ConfToml) *QPSPerSlackEndpoint {
+	qps := conf.Core.QPS
+	if qps <= 0 {
+		return nil
+	}
+
+	return &QPSPerSlackEndpoint{
+		ratelimit.NewBucketWithRate(float64(qps), int64(qps)),
+	}
+}
+
+func (qpsend QPSPerSlackEndpoint) Available() bool {
+	if qpsend.bucket.TakeAvailable(1) == 0 {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
I would like to use a slackboard to prevent an `Outgoing Webhook` from being forcibly invalidated due to [Rate Limits](https://api.slack.com/docs/rate-limits).

A `QPS ratelimitting function` enables this. If a value of qps is not specified in the configuration as before, the behavior is not changed at all.

To test,

```
# I executed requests at the same time, 
# and confirmed that second one is limited

$ curl -i -X POST -d '{"tag":"random","text":"test","sync":true}' \
"http://localhost:29800/notify"
HTTP/1.1 200 OK
Content-Type: application/json
Server: slackboard 0.7.1
Date: Sun, 22 Jan 2017 01:49:37 GMT
Content-Length: 16

{"message":"ok"}% 

$ curl -i -X POST -d '{"tag":"random","text":"test","sync":true}' \
"http://localhost:29800/notify"
HTTP/1.1 429 Too Many Requests
Content-Type: text/plain; charset=utf-8
Server: slackboard 0.7.1
X-Content-Type-Options: nosniff
Date: Sun, 22 Jan 2017 01:49:37 GMT
Content-Length: 46

{"message":"failed to post message to slack"}
```