### PR TITLE
Allow to accept server name starts with scheme

### DIFF
--- a/slackboard/cli.go
+++ b/slackboard/cli.go
@@ -33,7 +33,11 @@ func sendNotification2Slackboard(server, api, body string) error {
 	} else {
 		// TCP
 		client = &http.Client{}
+
 		url = fmt.Sprintf("http://%s/%s", server, api)
+		if strings.HasPrefix(server, "http://") || strings.HasPrefix(server, "https://") {
+			url = fmt.Sprintf("%s/%s", server, api)
+		}
 	}
 
 	resp, err := client.Post(


### PR DESCRIPTION
This PR allows slackboard-cli to accept url start with schema 'http' or 'https'.