### PR TITLE
Use retryablehttp in slackboard-cli

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cubicdaiya/slackboard
 require (
 	github.com/BurntSushi/toml v0.3.0
 	github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa
+	github.com/hashicorp/go-retryablehttp v0.5.4
 	github.com/juju/ratelimit v0.0.0-20151125201925-77ed1c8a0121
 	github.com/sirupsen/logrus v1.0.3
 	golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/BurntSushi/toml v0.3.0 h1:e1/Ivsx3Z0FVTV0NSOv/aVgbUWyQuzj7DDnFblkRvsY
 github.com/BurntSushi/toml v0.3.0/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa h1:YxLexpeQS0Fz/sNa3QQEgLWyVhgNhEB1GQUi+c45nFs=
 github.com/fukata/golang-stats-api-handler v0.0.0-20160325105040-ab9f90f16caa/go.mod h1:1sIi4/rHq6s/ednWMZqTmRq3765qTUSs/c3xF6lj8J8=
+github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
+github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-retryablehttp v0.5.4 h1:1BZvpawXoJCWX6pNtow9+rpEj+3itIlutiqnntI6jOE=
+github.com/hashicorp/go-retryablehttp v0.5.4/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/juju/ratelimit v0.0.0-20151125201925-77ed1c8a0121 h1:tK7/W+/VbVcqFcQzl3qMnrc/z3h/XOBIrJ9e/cv5hx4=
 github.com/juju/ratelimit v0.0.0-20151125201925-77ed1c8a0121/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/sirupsen/logrus v1.0.3 h1:B5C/igNWoiULof20pKfY4VntcIPqKuwEmoLZrabbUrc=


### PR DESCRIPTION
slackboard-cli failed when server temporally unavailable.
This PR allow slackboard-cli retry request to server.