### PR TITLE
support chat.postMessage backend

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -10,12 +10,13 @@ A configuration for Slackboard has some sections. A example is [here](conf/slack
 
 ## Core Section
 
-|name     |type  |description                    |default|note                                 |
-|---------|------|-------------------------------|-------|-------------------------------------|
-|port     |string|port number or unix socket path|29800  |e.g.)29800, unix:/tmp/slackboard.sock|
-|slack_url|string|Incomming Webhook url for slack|       |                                     |
-|qps      |int   |Queries to slack Per Second    |0      |0 means unlimited. See also [slack api docs](https://api.slack.com/docs/rate-limits) |
-|max_delay_duration |int   |Allowable delay message seconds    |      |must be specified when using qps > 0 and planning to process requests with sync=false |
+|name               |type  |description                    |default|note                                 |
+|-------------------|------|-------------------------------|-------|-------------------------------------|
+|port               |string|port number or unix socket path|29800  |e.g.)29800, unix:/tmp/slackboard.sock|
+|slack_url          |string|Incomming Webhook url for slack|       |If slack_token is specified, this field won't be used.|
+|slack_token        |string|Slack token to post messages   |       |token with permission to use [chat.postMessage](https://api.slack.com/methods/chat.postMessage)|
+|qps                |int   |Queries to slack Per Second    |0      |0 means unlimited. See also [slack api docs](https://api.slack.com/docs/rate-limits) |
+|max_delay_duration |int   |Allowable delay message seconds|       |must be specified when using qps > 0 and planning to process requests with sync=false |
 
 ## Tag Section
 

--- a/conf/slackboard.toml
+++ b/conf/slackboard.toml
@@ -1,6 +1,7 @@
 [core]
 port = "29800"
-slack_url = "https://hooks.slack.com/services/..."
+slack_url = "https://hooks.slack.com/services/..." # if you use Legacy Incoming Webhooks
+slack_token = "xoxb-00000-00000-xxxxxxxxxxx"       # post messages as Slack App Bot User
 
 [[tags]]
 tag = "general"

--- a/slackboard/conf.go
+++ b/slackboard/conf.go
@@ -15,6 +15,7 @@ type ConfToml struct {
 type SectionCore struct {
 	Port             string `toml:"port"`
 	SlackURL         string `toml:"slack_url"`
+	SlackToken       string `toml:"slack_token"`
 	QPS              int    `toml:"qps"`
 	MaxDelayDuration int    `toml:"max_delay_duration"`
 }
@@ -42,6 +43,7 @@ func BuildDefaultConf() ConfToml {
 	// Core
 	conf.Core.Port = "29800"
 	conf.Core.SlackURL = ""
+	conf.Core.SlackToken = ""
 	conf.Core.QPS = 0
 	conf.Core.MaxDelayDuration = -1 // means an empty parameter
 	// Log

--- a/slackboard/notify.go
+++ b/slackboard/notify.go
@@ -1,12 +1,16 @@
 package slackboard
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"time"
+)
+
+var (
+	SlackPostMessageAPIURL = `https://slack.com/api/chat.postMessage`
 )
 
 type SlackPayloadAttachmentsField struct {
@@ -78,19 +82,55 @@ func sendNotification2Slack(payload *SlackPayload, sync bool) (int, error) {
 		Timeout: 30 * time.Second,
 	}
 
-	resp, err := client.Post(
-		ConfSlackboard.Core.SlackURL,
-		"application/json",
-		strings.NewReader(string(body)))
+	if len(ConfSlackboard.Core.SlackToken) == 0 {
+		// if SlackToken is not specified, use Incoming Webhook
+		resp, err := client.Post(
+			ConfSlackboard.Core.SlackURL,
+			"application/json",
+			bytes.NewReader(body),
+		)
+		if err != nil {
+			return http.StatusBadGateway, err
+		}
+		defer resp.Body.Close()
 
+		if resp.StatusCode != http.StatusOK {
+			return http.StatusBadGateway, fmt.Errorf("Slack is not available:%s", resp.Status)
+		}
+
+		return http.StatusOK, nil
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		SlackPostMessageAPIURL,
+		bytes.NewReader(body),
+	)
 	if err != nil {
 		return http.StatusBadGateway, err
 	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ConfSlackboard.Core.SlackToken)
 
+	resp, err := client.Do(req)
+	if err != nil {
+		return http.StatusBadGateway, err
+	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		return http.StatusBadGateway, fmt.Errorf("Slack is not available:%s", resp.Status)
+	}
+
+	var errResp struct {
+		OK    bool   `json:"ok"`
+		Error string `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&errResp); err != nil {
+		return http.StatusBadGateway, fmt.Errorf("Slack returned invalid format response, should be json: %s", err)
+	}
+	if !errResp.OK {
+		return http.StatusBadGateway, fmt.Errorf("Slack returned error response: %s", errResp.Error)
 	}
 
 	return http.StatusOK, nil

--- a/slackboard/notify.go
+++ b/slackboard/notify.go
@@ -102,7 +102,7 @@ func sendNotification2Slack(payload *SlackPayload, sync bool) (int, error) {
 	}
 
 	req, err := http.NewRequest(
-		"POST",
+		http.MethodPost,
 		SlackPostMessageAPIURL,
 		bytes.NewReader(body),
 	)
@@ -157,7 +157,7 @@ func NotifyHandler(w http.ResponseWriter, r *http.Request) {
 	LogAcceptedRequest(r, req.Tag)
 
 	LogError.Debug("method check")
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		sendResponse(w, "invalid method", http.StatusBadRequest)
 		return
 	}
@@ -257,7 +257,7 @@ func NotifyDirectlyHandler(w http.ResponseWriter, r *http.Request) {
 	LogAcceptedRequest(r, req.Payload.Channel)
 
 	LogError.Debug("method check")
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		sendResponse(w, "invalid method", http.StatusBadRequest)
 		return
 	}

--- a/slackboard/notify_test.go
+++ b/slackboard/notify_test.go
@@ -19,7 +19,113 @@ type Log struct {
 	bytes.Buffer
 }
 
-func TestNotifyDirectlyHandler(t *testing.T) {
+func TestNotifyDirectlyHandler_PostMessage(t *testing.T) {
+	var testData = []struct {
+		in  string
+		out string
+	}{
+		{
+			`{
+                "payload": {
+                    "channel": "random",
+                    "username": "slackboard",
+                    "icon_emoji": ":clipboard:",
+                    "text": "notification text",
+                    "parse": "full"
+                },
+                "sync": true
+            }`,
+			`{
+                "channel":"random",
+                "username":"slackboard",
+                "icon_emoji":":clipboard:",
+                "text":"notification text",
+                "parse":"full",
+                "attachments":null
+            }`,
+		},
+		{
+			`{
+                "payload": {
+                    "channel": "general",
+                    "username": "bot",
+                    "icon_emoji": ":information_desk_person:",
+                    "text": "notification general text",
+                    "parse": "full"
+                },
+                "sync": true
+            }`,
+			`{
+                "channel":"general",
+                "username":"bot",
+                "icon_emoji":":information_desk_person:",
+                "text":"notification general text",
+                "parse":"full",
+                "attachments":null
+            }`,
+		},
+	}
+
+	for _, tt := range testData {
+		// setup a mock slack server
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ctype := r.Header.Get("Content-Type"); ctype != "application/json" {
+				t.Errorf("content type header: got %v want %v", ctype, "application/json")
+			}
+			if auth := r.Header.Get("Authorization"); auth != "Bearer xxxx-testtoken" {
+				t.Errorf("authorization header: got %v want %v", auth, "Bearer xxxx-testtoken")
+			}
+
+			reqBody, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			jsonIsEqual, err := jsonBytesEqual(reqBody, []byte(tt.out))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !jsonIsEqual {
+				t.Errorf("unexpected body: got %v want %v", string(reqBody), tt.out)
+			}
+
+			fmt.Fprint(w, `{"ok":true}`)
+		}))
+		defer ts.Close()
+		SlackPostMessageAPIURL = ts.URL
+		ConfSlackboard.Core.SlackToken = "xxxx-testtoken"
+
+		// setup a test client
+		req, err := http.NewRequest(
+			"POST",
+			"/notify-directly",
+			bytes.NewBuffer([]byte(tt.in)),
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		rr := httptest.NewRecorder()
+		handler := http.HandlerFunc(NotifyDirectlyHandler)
+		handler.ServeHTTP(rr, req)
+
+		// check a response
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("status code: got %v want %v", status, http.StatusOK)
+		}
+
+		expected := `{"message":"ok"}`
+		jsonIsEqual, err := jsonBytesEqual(rr.Body.Bytes(), []byte(expected))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !jsonIsEqual {
+			t.Errorf("unexpected body: got %v want %v", rr.Body.String(), expected)
+		}
+	}
+}
+
+func TestNotifyDirectlyHandler_IncomingWebhook(t *testing.T) {
 	var testData = []struct {
 		in  string
 		out string
@@ -90,6 +196,7 @@ func TestNotifyDirectlyHandler(t *testing.T) {
 		}))
 		defer ts.Close()
 		ConfSlackboard.Core.SlackURL = ts.URL
+		ConfSlackboard.Core.SlackToken = ""
 
 		// setup a test client
 		req, err := http.NewRequest(
@@ -121,13 +228,62 @@ func TestNotifyDirectlyHandler(t *testing.T) {
 	}
 }
 
-func TestNotifyDirectlyHandlerSlackServerError(t *testing.T) {
+func TestNotifyDirectlyHandlerSlackServerError_PostMessage(t *testing.T) {
+	// setup a mock slack server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, `{"ok":false, "error":"error-message"}`)
+	}))
+	defer ts.Close()
+	SlackPostMessageAPIURL = ts.URL
+	ConfSlackboard.Core.SlackToken = "xxxx-testtoken"
+
+	// setup a test client
+	inJSONStr := `{
+        "payload": {
+            "channel": "random",
+            "username": "slackboard",
+            "icon_emoji": ":clipboard:",
+            "text": "notification text",
+            "parse": "full"
+        },
+        "sync": true
+    }`
+	req, err := http.NewRequest(
+		"POST",
+		"/notify-directly",
+		bytes.NewBuffer([]byte(inJSONStr)),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(NotifyDirectlyHandler)
+	handler.ServeHTTP(rr, req)
+
+	// check a response
+	if status := rr.Code; status != http.StatusBadGateway {
+		t.Errorf("status code: got %v want %v", status, http.StatusBadGateway)
+	}
+
+	expected := `{"message":"failed to post message to slack"}`
+	jsonIsEqual, err := jsonBytesEqual(rr.Body.Bytes(), []byte(expected))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !jsonIsEqual {
+		t.Errorf("unexpected body: got %v want %v", rr.Body.String(), expected)
+	}
+}
+
+func TestNotifyDirectlyHandlerSlackServerError_IncomingWebhook(t *testing.T) {
 	// setup a mock slack server
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Server down", http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 	ConfSlackboard.Core.SlackURL = ts.URL
+	ConfSlackboard.Core.SlackToken = ""
 
 	// setup a test client
 	inJSONStr := `{

--- a/slackboard/notify_test.go
+++ b/slackboard/notify_test.go
@@ -97,7 +97,7 @@ func TestNotifyDirectlyHandler_PostMessage(t *testing.T) {
 
 		// setup a test client
 		req, err := http.NewRequest(
-			"POST",
+			http.MethodPost,
 			"/notify-directly",
 			bytes.NewBuffer([]byte(tt.in)),
 		)
@@ -200,7 +200,7 @@ func TestNotifyDirectlyHandler_IncomingWebhook(t *testing.T) {
 
 		// setup a test client
 		req, err := http.NewRequest(
-			"POST",
+			http.MethodPost,
 			"/notify-directly",
 			bytes.NewBuffer([]byte(tt.in)),
 		)
@@ -249,7 +249,7 @@ func TestNotifyDirectlyHandlerSlackServerError_PostMessage(t *testing.T) {
         "sync": true
     }`
 	req, err := http.NewRequest(
-		"POST",
+		http.MethodPost,
 		"/notify-directly",
 		bytes.NewBuffer([]byte(inJSONStr)),
 	)
@@ -297,7 +297,7 @@ func TestNotifyDirectlyHandlerSlackServerError_IncomingWebhook(t *testing.T) {
         "sync": true
     }`
 	req, err := http.NewRequest(
-		"POST",
+		http.MethodPost,
 		"/notify-directly",
 		bytes.NewBuffer([]byte(inJSONStr)),
 	)
@@ -484,7 +484,7 @@ func TestNotifyDirectlyHandlerQPS(t *testing.T) {
 		for i := 0; i < qcount; i++ {
 			go func() {
 				req, err := http.NewRequest(
-					"POST",
+					http.MethodPost,
 					"/notify-directly",
 					bytes.NewBuffer([]byte(createInJSONStr(tt.in["sync"].(string)))),
 				)


### PR DESCRIPTION
Slack don't recommend to use Legacy Incoming Webhooks ([link](https://api.slack.com/custom-integrations/incoming-webhooks)) and new Slack Incoming Webhooks does not permit to override channel and others anymore ([link](https://api.slack.com/incoming-webhooks)).
So I suggest to use [`chat.postMessage`](https://api.slack.com/methods/chat.postMessage) API instead of Incoming Webhooks.